### PR TITLE
changes from feature to unit test cases

### DIFF
--- a/tests/unit/EasypaisaDirectTest.php
+++ b/tests/unit/EasypaisaDirectTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Unit;
 
 use Tests\TestCase;
 use Illuminate\Support\Str;

--- a/tests/unit/EasypaisaHostedTest.php
+++ b/tests/unit/EasypaisaHostedTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Unit;
 
 use Illuminate\Http\JsonResponse;
 use Tests\TestCase;
@@ -10,7 +10,7 @@ use Zfhassaan\Easypaisa\Easypaisa;
 class EasypaisaHostedTest extends TestCase
 {
     /**
-     * A basic feature test example.
+     * A basic Unit test example.
      */
     public function testSendHostedRequest()
 {


### PR DESCRIPTION
Namespace changes from `Tests\Feature` to `Tests\Unit` due to issue of publishing assets and following PSR-4 standards. 
The commit also fixes the namespace issue for the TestCases defined.